### PR TITLE
Add setting to exclude weapons with Splattercolor Screen

### DIFF
--- a/js/bingoBoard-v5.js
+++ b/js/bingoBoard-v5.js
@@ -72,10 +72,13 @@ class BingoBoard {
             let currentWeaponList = tempWeaponsMap.get(currentKey);
             for (let k=0; k<5; k++) {
                 let index = Math.floor(Math.random() * currentWeaponList.length);
-                console.log(index);
                 let chosenWeapon = currentWeaponList[index];
                 let boardIndex = this.template[j][k];
                 board[boardIndex] = chosenWeapon;
+                if (this.isSplatScreenEnabled === false && splatScreenWeapons.includes(chosenWeapon.name)) {
+                    // pick a different weapon
+                    k--;
+                }
                 currentWeaponList.splice(index, 1);
             }
             tempWeaponsMap.set(currentKey, currentWeaponList);

--- a/js/bingoBoard-v5.js
+++ b/js/bingoBoard-v5.js
@@ -51,7 +51,6 @@ class BingoBoard {
                 // pick a different weapon
                 i--;
             }
-            console.log(splatScreenWeapons.includes(chosenWeapon));
             tempWeapons.splice(index, 1);
         }
         return board;

--- a/js/bingoBoard-v5.js
+++ b/js/bingoBoard-v5.js
@@ -11,11 +11,12 @@ class BingoBoard {
     #t8 = [[0, 9, 13, 16, 22], [1, 7, 14, 18, 20], [2, 8, 11, 15, 24], [3, 5, 12, 19, 21], [4, 6, 10, 17, 23]];
     #allTemplates = [this.#t1, this.#t2, this.#t3, this.#t4, this.#t5, this.#t6, this.#t7, this.#t8];
 
-    constructor(weaponMap, seed, isBalancedCard) {
+    constructor(weaponMap, seed, isBalancedCard, isSplatScreenEnabled) {
         Math.seedrandom(seed);
         this.seed = seed;
         this.weaponMap = weaponMap;
         this.isBalancedCard = isBalancedCard;
+        this.isSplatScreenEnabled = isSplatScreenEnabled;
         this.template = this.#allTemplates[Math.floor(Math.random() * this.#allTemplates.length)];
         this.board = this.setupBoard();
     }
@@ -46,6 +47,11 @@ class BingoBoard {
             let index = Math.floor(Math.random() * tempWeapons.length);
             let chosenWeapon = tempWeapons[index];
             board[i] = chosenWeapon;
+            if (this.isSplatScreenEnabled === false && splatScreenWeapons.includes(chosenWeapon.name)) {
+                // pick a different weapon
+                i--;
+            }
+            console.log(splatScreenWeapons.includes(chosenWeapon));
             tempWeapons.splice(index, 1);
         }
         return board;
@@ -67,6 +73,7 @@ class BingoBoard {
             let currentWeaponList = tempWeaponsMap.get(currentKey);
             for (let k=0; k<5; k++) {
                 let index = Math.floor(Math.random() * currentWeaponList.length);
+                console.log(index);
                 let chosenWeapon = currentWeaponList[index];
                 let boardIndex = this.template[j][k];
                 board[boardIndex] = chosenWeapon;

--- a/js/bingov7.js
+++ b/js/bingov7.js
@@ -3,7 +3,7 @@ var randomWeaponPool = [];
 var isRandomWeaponsPoolPopulated = false;
 var myBingoBoard;
 var myWeaponRandomizer;
-var isSplatScreenEnabled = true;
+var isSplatScreenEnabled;
 
 var bingo = function(weaponMap) {
 
@@ -33,6 +33,10 @@ var bingo = function(weaponMap) {
 
     if(SPLATSCREEN.toLowerCase() == "disabled") {
         isSplatScreenEnabled = false;
+        $("input[id=noSplatScreen]").prop("checked", true);
+    } else {
+        isSplatScreenEnabled = true;
+        $("input[id=yesSplatScreen]").prop("checked", true);
     }
 
     myBingoBoard = new BingoBoard(weaponMap, SEED, isBalancedCard, isSplatScreenEnabled);
@@ -177,13 +181,13 @@ function enableSeed() {
     document.getElementById("mySeed").disabled = false;
 }
 
-function reseedPage(isBalancedCard, isSplatScreenEnabled) {
+function reseedPage(isBalancedCard) {
     Math.seedrandom();
 	var urlParams = "?seed=" + Math.ceil(999999 * Math.random());
     if (!isBalancedCard) {
         urlParams = urlParams + "&mode=chaos";
     }
-    if (!isSplatScreenEnabled) {
+    if (document.getElementById("noSplatScreen").checked === true) {
         urlParams = urlParams + "&splatscreen=disabled";
     }
 	window.location = urlParams;

--- a/js/bingov7.js
+++ b/js/bingov7.js
@@ -3,6 +3,7 @@ var randomWeaponPool = [];
 var isRandomWeaponsPoolPopulated = false;
 var myBingoBoard;
 var myWeaponRandomizer;
+var isSplatScreenEnabled = true;
 
 var bingo = function(weaponMap) {
 
@@ -30,7 +31,6 @@ var bingo = function(weaponMap) {
         SPLATSCREEN = "enabled";
     }
 
-    let isSplatScreenEnabled = true;
     if(SPLATSCREEN.toLowerCase() == "disabled") {
         isSplatScreenEnabled = false;
     }
@@ -138,7 +138,7 @@ function initializeRandomizer() {
     if (document.getElementById("randomSet").checked === true) {
         seed = document.getElementById("mySeed").value;
     }
-    myWeaponRandomizer = new WeaponRandomizer(myBingoBoard, seed, isUsingAllWeapons, isAllowingRepeats, isIgnoreSeed);
+    myWeaponRandomizer = new WeaponRandomizer(myBingoBoard, seed, isUsingAllWeapons, isAllowingRepeats, isIgnoreSeed, isSplatScreenEnabled);
 }
 
 function updateRandomWeapon(currentObj) {

--- a/js/bingov7.js
+++ b/js/bingov7.js
@@ -11,7 +11,7 @@ var bingo = function(weaponMap) {
 
     let SEED = urlParams.get('seed');
 	if(SEED === undefined || SEED === null || SEED === "") {
-        return reseedPage(true);
+        return reseedPage(true, true);
     }
 	Math.seedrandom(SEED); //sets up the RNG
 
@@ -25,7 +25,17 @@ var bingo = function(weaponMap) {
         isBalancedCard = false;
     }
 
-    myBingoBoard = new BingoBoard(weaponMap, SEED, isBalancedCard);
+    let SPLATSCREEN = urlParams.get('splatscreen');
+    if(SPLATSCREEN === undefined || SPLATSCREEN === null || SPLATSCREEN.toLowerCase() !== "disabled") {
+        SPLATSCREEN = "enabled";
+    }
+
+    let isSplatScreenEnabled = true;
+    if(SPLATSCREEN.toLowerCase() == "disabled") {
+        isSplatScreenEnabled = false;
+    }
+
+    myBingoBoard = new BingoBoard(weaponMap, SEED, isBalancedCard, isSplatScreenEnabled);
 
 	var results = $("#results");
 	results.append ("<p>Splatoon3Bingo.com <strong>v7</strong>&emsp;Mode: <strong>" + MODE[0].toUpperCase() + MODE.substring(1) + "</strong>&emsp;Seed: <strong>" +
@@ -167,11 +177,14 @@ function enableSeed() {
     document.getElementById("mySeed").disabled = false;
 }
 
-function reseedPage(isBalancedCard) {
+function reseedPage(isBalancedCard, isSplatScreenEnabled) {
     Math.seedrandom();
 	var urlParams = "?seed=" + Math.ceil(999999 * Math.random());
     if (!isBalancedCard) {
         urlParams = urlParams + "&mode=chaos";
+    }
+    if (!isSplatScreenEnabled) {
+        urlParams = urlParams + "&splatscreen=disabled";
     }
 	window.location = urlParams;
 	return false;

--- a/js/weaponRandomizer.js
+++ b/js/weaponRandomizer.js
@@ -1,11 +1,12 @@
 class WeaponRandomizer {
-    constructor(bingoBoard, seed, isUsingAllWeapons, isAllowingRepeats, isIgnoreSeed) {
+    constructor(bingoBoard, seed, isUsingAllWeapons, isAllowingRepeats, isIgnoreSeed, isSplatScreenEnabled) {
         this.weaponMap = bingoBoard.weaponMap;
         this.board = bingoBoard.board;
         this.seed = seed;
         this.isIgnoreSeed = isIgnoreSeed;
         this.isUsingAllWeapons = isUsingAllWeapons;
         this.isAllowingRepeats = isAllowingRepeats;
+        this.isSplatScreenEnabled = isSplatScreenEnabled;
         this.pool = this.setupPool();
         this.index = -1;
     }
@@ -42,6 +43,11 @@ class WeaponRandomizer {
         for (let key in mapKeys) {
             let value = this.weaponMap.get(mapKeys[key]);
             for (let val in value) {
+                console.log(value[val].name);
+                if (this.isSplatScreenEnabled === false && splatScreenWeapons.includes(value[val].name)) {
+                    // skip this weapon
+                    continue;
+                }
                 result.push(value[val]);
             }
         }

--- a/tables/s3weaponsv7.js
+++ b/tables/s3weaponsv7.js
@@ -158,6 +158,13 @@ var miscList = [
     {name: "Neo Splatana Stamper", image:"../weapons/107.png", types: "Splatana"}
 ]
 
+var splatScreenWeapons = [
+    "Foil Flingza Roller",
+    "Undercover Sorella Brella",
+    "Foil Squeezer",
+    ".52 Gal Deco"
+]
+
 weaponMap.set('Frontline', frontLineShooterList);
 weaponMap.set('Backline', backLineShooterList);
 weaponMap.set('Splattershot', splattershotList);

--- a/v7/index.html
+++ b/v7/index.html
@@ -27,15 +27,18 @@
             <h2>Generate a new card</h2>
 
             <p><span class="note">Please note that if you got linked to this page as your goal, you are not allowed to use a different card.</span></p>
-            <a class="sortButton" href="#" onclick="reseedPage(true, true);">New Balanced Card</a>
-            <a class="sortButton" href="#" onclick="reseedPage(false, true);">New Chaos Card</a>
-            <a class="sortButton" href="#" onclick="reseedPage(true, false);">New Balanced Card (No Splattercolor Screen)</a>
-            <a class="sortButton" href="#" onclick="reseedPage(false, false);">New Chaos Card (No Splattercolor Screen)</a>
+            <a class="sortButton" href="#" onclick="reseedPage(true);">New Balanced Card</a>
+            <a class="sortButton" href="#" onclick="reseedPage(false);">New Chaos Card</a>
 
             <h2>Settings</h2>
             <a class="sortButton" href="#" onclick="refreshBoard(false);">Hide Weapon Names</a>
             <a class="sortButton" href="#" onclick="refreshBoard(true);">Show Weapon Names</a>
-            <br>
+            <br><br>
+            <p>Allow Weapons with Splattercolor Screen?</p>
+            <input type="radio" id="yesSplatScreen" name="radioSplatScreen" onclick="reseedPage(true);" value="1">
+            <label for="yesSplatScreen">Yes</label><br>
+            <input type="radio" id="noSplatScreen" name="radioSplatScreen" onclick="reseedPage(true);" value="0">
+            <label for="noSplatScreen">No</label><br>
             <h2>Random Weapon Assignment</h2>
             <input type="radio" id="randomIgnore" name="radioRandom" onclick="disableSeed()" value="0">
             <label for="randomIgnore">Ignore Seed</label><br>

--- a/v7/index.html
+++ b/v7/index.html
@@ -27,8 +27,10 @@
             <h2>Generate a new card</h2>
 
             <p><span class="note">Please note that if you got linked to this page as your goal, you are not allowed to use a different card.</span></p>
-            <a class="sortButton" href="#" onclick="reseedPage(true);">New Balanced Card</a>
-            <a class="sortButton" href="#" onclick="reseedPage(false);">New Chaos Card</a>
+            <a class="sortButton" href="#" onclick="reseedPage(true, true);">New Balanced Card</a>
+            <a class="sortButton" href="#" onclick="reseedPage(false, true);">New Chaos Card</a>
+            <a class="sortButton" href="#" onclick="reseedPage(true, false);">New Balanced Card (No Splattercolor Screen)</a>
+            <a class="sortButton" href="#" onclick="reseedPage(false, false);">New Chaos Card (No Splattercolor Screen)</a>
 
             <h2>Settings</h2>
             <a class="sortButton" href="#" onclick="refreshBoard(false);">Hide Weapon Names</a>


### PR DESCRIPTION
Hi, I hope you're having a great day. :D
I decided it would be a good idea to add a feature to be able to exclude Splattercolor Screen weapons from the weapon pool for the randomizer + the bingo board, in case this was being used in a Private Battle setting where there are people who are known to be negatively affected by Splattercolor Screen (or any other setting where one may want to be cautious about using it).
By default, Splattercolor Screen weapons are allowed, but you can disable them with the two radio buttons I added under the "Settings" section.
Thanks for making an awesome game, I've been watching a bunch of streamers play it :D